### PR TITLE
mip best bound

### DIFF
--- a/src/MathOptInterfaceXpress.jl
+++ b/src/MathOptInterfaceXpress.jl
@@ -513,8 +513,8 @@ LQOI.get_objective_bound(instance::XpressOptimizer) = XPR.get_bestbound(instance
 
 function LQOI.get_relative_mip_gap(instance::XpressOptimizer)
     best_feasible_solution = XPR.get_mip_objval(instance.inner)
-    best_prossible_solution = XPR.get_bestbound(instance.inner)
-    return abs((Ubest_prossible_solution-best_feasible_solution)/best_prossible_solution)
+    best_possible_solution = XPR.get_bestbound(instance.inner)
+    return abs((best_possible_solution-best_feasible_solution)/best_possible_solution)
 end
 
 LQOI.get_iteration_count(instance::XpressOptimizer)  = XPR.get_simplex_iter_count(instance.inner)

--- a/src/MathOptInterfaceXpress.jl
+++ b/src/MathOptInterfaceXpress.jl
@@ -509,12 +509,12 @@ end
 
 LQOI.get_objective_value(instance::XpressOptimizer) = XPR.get_objval(instance.inner)
 
-LQOI.get_objective_bound(instance::XpressOptimizer) = XPR.get_mip_objval(instance.inner)
+LQOI.get_objective_bound(instance::XpressOptimizer) = XPR.get_bestbound(instance.inner)
 
 function LQOI.get_relative_mip_gap(instance::XpressOptimizer)
-    L = XPR.get_mip_objval(instance.inner)
-    U = XPR.get_bestbound(instance.inner)
-    return abs(U-L)/U
+    best_feasible_solution = XPR.get_mip_objval(instance.inner)
+    best_prossible_solution = XPR.get_bestbound(instance.inner)
+    return abs((Ubest_prossible_solution-best_feasible_solution)/best_prossible_solution)
 end
 
 LQOI.get_iteration_count(instance::XpressOptimizer)  = XPR.get_simplex_iter_count(instance.inner)


### PR DESCRIPTION
The mip best bound was getting the best primal solution instead of the best possible solution.
Furthermore, the mip relative gap would return a negative value if both the lower and upper bound were negative.